### PR TITLE
Use master as the CI release branch

### DIFF
--- a/.github/workflows/daily-full-tests.yml
+++ b/.github/workflows/daily-full-tests.yml
@@ -8,13 +8,13 @@ on:
       ref:
         description: 'Branch or ref to test'
         required: false
-        default: 'develop'
+        default: 'master'
 
 permissions:
   contents: read
 
 concurrency:
-  group: daily-full-${{ github.event.inputs.ref || 'develop' }}
+  group: daily-full-${{ github.event.inputs.ref || 'master' }}
   cancel-in-progress: false
 
 jobs:
@@ -28,11 +28,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
-      - name: Checkout develop on scheduled run
+      - name: Checkout master on scheduled run
         if: github.event_name == 'schedule'
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: master
 
       - name: Set up Java 21
         uses: actions/setup-java@v5

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -3,7 +3,6 @@ name: PR - Compile and Unit Tests
 on:
   pull_request:
     branches:
-      - develop
       - master
     types:
       - opened

--- a/src/main/java/com/mgrtech/sponti_api/auth/internal/security/SecurityConfig.java
+++ b/src/main/java/com/mgrtech/sponti_api/auth/internal/security/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -39,7 +38,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain securityFilterChain(HttpSecurity http) {
         return http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
@@ -52,13 +51,15 @@ public class SecurityConfig {
                             "/api/v1/auth/register",
                             "/api/v1/auth/login",
                             "/api/v1/auth/refresh",
-                            "/actuator/health",
-                            "/v3/api-docs/**",
-                            "/swagger-ui/**",
-                            "/swagger-ui.html"
+                            "/actuator/health"
                     ).permitAll();
 
                     if (isLocalProfile()) {
+                        registry.requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll();
                         registry.requestMatchers("/actuator/prometheus").permitAll();
                     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,6 +8,12 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST:localhost}
       port: ${SPRING_DATA_REDIS_PORT:6379}
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,12 @@ spring:
   flyway:
     enabled: true
 
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary
- cherry-pick `Disabling swagger on prod` onto the master release path
- update PR checks to target `master` only
- update daily full tests to default to and schedule against `master`

## Notes
This supports a trunk-based flow where feature branches open PRs directly into `master`, and merged changes produce release/image tags through the existing master release workflows.

## Verification
- `rg -n "develop" .github/workflows` returns no matches
- `./mvnw -B -ntp test` compiles, but local integration tests fail because Testcontainers cannot find a Docker environment